### PR TITLE
Incorporation  k60 120

### DIFF
--- a/gen/inc/cortexM4/Os_Internal_Arch_Cfg.h.php
+++ b/gen/inc/cortexM4/Os_Internal_Arch_Cfg.h.php
@@ -3,7 +3,7 @@
  ********************************************************/
 
 /* Copyright 2014, Pablo Ridolfi (UTN-FRBA)
- *
+ * All rights reserved.
  *
  * This file is part of CIAA Firmware.
  *

--- a/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
@@ -84,7 +84,6 @@
   void __thumb_startup( void );
 
   extern uint32_t __SP_INIT;
-  //extern uint32_t __SP_INIT;
 
 #else
 
@@ -140,6 +139,204 @@ void DebugMon_Handler(void) {
 }
 
 /*==================[external functions definition]==========================*/
+
+<?php
+/* Interrupt sources for MK60F15.
+ * See externals/platforms/cortexM4/k60_120/inc/MK60F15.h.
+ */
+$intList_k60_120 = array (
+   0 => "Initial_Stack_Pointer",
+   1 => "Initial_Program_Counter",
+   2 => "NMI",
+   3 => "Hard_Fault",
+   4 => "Mem_Manage_Fault",
+   5 => "Bus_Fault",
+   6 => "Usage_Fault",
+   7 => "Reserved7",
+   8 => "Reserved8",
+   9 => "Reserved9",
+   10 => "Reserved10",
+   11 => "SVCall",
+   12 => "DebugMonitor",
+   13 => "Reserved13",
+   14 => "PendableSrvReq",
+   15 => "SysTick",
+   16 => "DMA0_DMA16",
+   17 => "DMA1_DMA17",
+   18 => "DMA2_DMA18",
+   19 => "DMA3_DMA19",
+   20 => "DMA4_DMA20",
+   21 => "DMA5_DMA21",
+   22 => "DMA6_DMA22",
+   23 => "DMA7_DMA23",
+   24 => "DMA8_DMA24",
+   25 => "DMA9_DMA25",
+   26 => "DMA10_DMA26",
+   27 => "DMA11_DMA27",
+   28 => "DMA12_DMA28",
+   29 => "DMA13_DMA29",
+   30 => "DMA14_DMA30",
+   31 => "DMA15_DMA31",
+   32 => "DMA_Error",
+   33 => "MCM",
+   34 => "FTFE",
+   35 => "Read_Collision",
+   36 => "LVD_LVW",
+   37 => "LLW",
+   38 => "Watchdog",
+   39 => "RNG",
+   40 => "I2C0",
+   41 => "I2C1",
+   42 => "SPI0",
+   43 => "SPI1",
+   44 => "SPI2",
+   45 => "CAN0_ORed_Message_buffer",
+   46 => "CAN0_Bus_Off",
+   47 => "CAN0_Error",
+   48 => "CAN0_Tx_Warning",
+   49 => "CAN0_Rx_Warning",
+   50 => "CAN0_Wake_Up",
+   51 => "I2S0_Tx",
+   52 => "I2S0_Rx",
+   53 => "CAN1_ORed_Message_buffer",
+   54 => "CAN1_Bus_Off",
+   55 => "CAN1_Error",
+   56 => "CAN1_Tx_Warning",
+   57 => "CAN1_Rx_Warning",
+   58 => "CAN1_Wake_Up",
+   59 => "Reserved59",
+   60 => "UART0_LON",
+   61 => "UART0_RX_TX",
+   62 => "UART0_ERR",
+   63 => "UART1_RX_TX",
+   64 => "UART1_ERR",
+   65 => "UART2_RX_TX",
+   66 => "UART2_ERR",
+   67 => "UART3_RX_TX",
+   68 => "UART3_ERR",
+   69 => "UART4_RX_TX",
+   70 => "UART4_ERR",
+   71 => "UART5_RX_TX",
+   72 => "UART5_ERR",
+   73 => "ADC0",
+   74 => "ADC1",
+   75 => "CMP0",
+   76 => "CMP1",
+   77 => "CMP2",
+   78 => "FTM0",
+   79 => "FTM1",
+   80 => "FTM2",
+   81 => "CMT",
+   82 => "RTC",
+   83 => "RTC_Seconds",
+   84 => "PIT0",
+   85 => "PIT1",
+   86 => "PIT2",
+   87 => "PIT3",
+   88 => "PDB0",
+   89 => "USB0",
+   90 => "USBDCD",
+   91 => "ENET_1588_Timer",
+   92 => "ENET_Transmit",
+   93 => "ENET_Receive",
+   94 => "ENET_Error",
+   95 => "Reserved95",
+   96 => "SDHC",
+   97 => "DAC0",
+   98 => "DAC1",
+   99 => "TSI0",
+   100 => "MCG",
+   101 => "LPTimer",
+   102 => "Reserved102",
+   103 => "PORTA",
+   104 => "PORTB",
+   105 => "PORTC",
+   106 => "PORTD",
+   107 => "PORTE",
+   108 => "PORTF",
+   109 => "Reserved109",
+   110 => "SWI",
+   111 => "NFC",
+   112 => "USBHS",
+   113 => "Reserved113",
+   114 => "CMP3",
+   115 => "Reserved115",
+   116 => "Reserved116",
+   117 => "FTM3",
+   118 => "ADC2",
+   119 => "ADC3",
+   120 => "I2S1_Tx",
+   121 => "I2S1_Rx",
+
+);
+
+$MAX_INT_COUNT_k60_120 = max(array_keys($intList_k60_120))+1;
+?>
+
+
+
+
+#if (CPU == mk60fx512vlq15)
+/** \brief mk60fx512vlq15 Interrupt vector */
+__attribute__ ((section (".vectortable"))) const tVectorTable __vect_table = { /* Interrupt vector table */
+  
+    /* ISR name                             No. Address      Pri Name                           Description */
+    &__SP_INIT,                        /* 0x00  0x00000000   -   ivINT_Initial_Stack_Pointer    used by PE */
+    {
+    (tIsrFunc)&__thumb_startup,        /* 0x01  0x00000004   -   ivINT_Initial_Program_Counter  used by PE */
+    (tIsrFunc)&Cpu_INT_NMIInterrupt,   /* 0x02  0x00000008   -2   ivINT_NMI                      used by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x03  0x0000000C   -1   ivINT_Hard_Fault               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x04  0x00000010   -   ivINT_Mem_Manage_Fault         unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x05  0x00000014   -   ivINT_Bus_Fault                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x06  0x00000018   -   ivINT_Usage_Fault              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x07  0x0000001C   -   ivINT_Reserved7                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x08  0x00000020   -   ivINT_Reserved8                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x09  0x00000024   -   ivINT_Reserved9                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0A  0x00000028   -   ivINT_Reserved10               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0B  0x0000002C   -   ivINT_SVCall                   unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0C  0x00000030   -   ivINT_DebugMonitor             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0D  0x00000034   -   ivINT_Reserved13               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0E  0x00000038   -   ivINT_PendableSrvReq           unused by PE */
+    (tIsrFunc)&SysTick_Handler,        /* 0x0F  0x0000003C   -   ivINT_SysTick                  unused by PE */
+<?php
+
+/* get ISRs defined by user application */
+$intnames = $config->getList("/OSEK","ISR");
+
+for($i=16; $i < $MAX_INT_COUNT_k60_120; $i++)
+{
+   $src_found = 0;
+   foreach ($intnames as $int)
+   {
+      $intcat = $config->getValue("/OSEK/" . $int,"CATEGORY");
+      $source = $config->getValue("/OSEK/" . $int,"INTERRUPT");
+
+      if($intList_k60_120[$i] == $source)
+      {
+         if ($intcat == 2)
+         {
+            print "    (tIsrFunc)&OSEK_ISR2_$int,          /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))." ISR for " . $intList_k60_120[$i] . " (IRQ $i) Category 2 */\n";
+            $src_found = 1;
+         } elseif ($intcat == 1)
+         {
+            print "    (tIsrFunc)&OSEK_ISR_$int,          /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))."  ISR for " . $intList_k60_120[$i] . " (IRQ $i) Category 1 */\n";
+            $src_found = 1;
+         } else
+         {
+            error("Interrupt $int type $inttype has an invalid category $intcat");
+         }
+      }
+   }
+   if($src_found == 0)
+   {
+      print "    (tIsrFunc)&OSEK_ISR_NoHandler,     /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))."   -   No Handler set for ISR " . $intList_k60_120[$i] . " (IRQ $i) */\n";
+   }
+}
+?>
+	}
+  };
+
+#else
 
 <?php
 /* Interrupt sources for LPC43xx.
@@ -203,139 +400,6 @@ $intList = array (
 
 $MAX_INT_COUNT = max(array_keys($intList))+1;
 ?>
-
-#if (CPU == mk60fx512vlq15)
-/** \brief mk60fx512vlq15 Interrupt vector */
-__attribute__ ((section (".vectortable"))) const tVectorTable __vect_table = { /* Interrupt vector table */
-  
-    /* ISR name                             No. Address      Pri Name                           Description */
-    &__SP_INIT,                        /* 0x00  0x00000000   -   ivINT_Initial_Stack_Pointer    used by PE */
-    {
-    (tIsrFunc)&__thumb_startup,        /* 0x01  0x00000004   -   ivINT_Initial_Program_Counter  used by PE */
-    (tIsrFunc)&Cpu_INT_NMIInterrupt,   /* 0x02  0x00000008   -2   ivINT_NMI                      used by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x03  0x0000000C   -1   ivINT_Hard_Fault               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x04  0x00000010   -   ivINT_Mem_Manage_Fault         unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x05  0x00000014   -   ivINT_Bus_Fault                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x06  0x00000018   -   ivINT_Usage_Fault              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x07  0x0000001C   -   ivINT_Reserved7                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x08  0x00000020   -   ivINT_Reserved8                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x09  0x00000024   -   ivINT_Reserved9                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x0A  0x00000028   -   ivINT_Reserved10               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x0B  0x0000002C   -   ivINT_SVCall                   unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x0C  0x00000030   -   ivINT_DebugMonitor             unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x0D  0x00000034   -   ivINT_Reserved13               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x0E  0x00000038   -   ivINT_PendableSrvReq           unused by PE */
-    (tIsrFunc)&SysTick_Handler,        /* 0x0F  0x0000003C   -   ivINT_SysTick                  unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x10  0x00000040   -   ivINT_DMA0_DMA16               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x11  0x00000044   -   ivINT_DMA1_DMA17               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x12  0x00000048   -   ivINT_DMA2_DMA18               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x13  0x0000004C   -   ivINT_DMA3_DMA19               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x14  0x00000050   -   ivINT_DMA4_DMA20               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x15  0x00000054   -   ivINT_DMA5_DMA21               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x16  0x00000058   -   ivINT_DMA6_DMA22               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x17  0x0000005C   -   ivINT_DMA7_DMA23               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x18  0x00000060   -   ivINT_DMA8_DMA24               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x19  0x00000064   -   ivINT_DMA9_DMA25               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x1A  0x00000068   -   ivINT_DMA10_DMA26              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x1B  0x0000006C   -   ivINT_DMA11_DMA27              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x1C  0x00000070   -   ivINT_DMA12_DMA28              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x1D  0x00000074   -   ivINT_DMA13_DMA29              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x1E  0x00000078   -   ivINT_DMA14_DMA30              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x1F  0x0000007C   -   ivINT_DMA15_DMA31              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x20  0x00000080   -   ivINT_DMA_Error                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x21  0x00000084   -   ivINT_MCM                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x22  0x00000088   -   ivINT_FTFE                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x23  0x0000008C   -   ivINT_Read_Collision           unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x24  0x00000090   -   ivINT_LVD_LVW                  unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x25  0x00000094   -   ivINT_LLW                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x26  0x00000098   -   ivINT_Watchdog                 unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x27  0x0000009C   -   ivINT_RNG                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x28  0x000000A0   -   ivINT_I2C0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x29  0x000000A4   -   ivINT_I2C1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x2A  0x000000A8   -   ivINT_SPI0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x2B  0x000000AC   -   ivINT_SPI1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x2C  0x000000B0   -   ivINT_SPI2                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x2D  0x000000B4   -   ivINT_CAN0_ORed_Message_buffer unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x2E  0x000000B8   -   ivINT_CAN0_Bus_Off             unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x2F  0x000000BC   -   ivINT_CAN0_Error               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x30  0x000000C0   -   ivINT_CAN0_Tx_Warning          unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x31  0x000000C4   -   ivINT_CAN0_Rx_Warning          unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x32  0x000000C8   -   ivINT_CAN0_Wake_Up             unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x33  0x000000CC   -   ivINT_I2S0_Tx                  unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x34  0x000000D0   -   ivINT_I2S0_Rx                  unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x35  0x000000D4   -   ivINT_CAN1_ORed_Message_buffer unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x36  0x000000D8   -   ivINT_CAN1_Bus_Off             unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x37  0x000000DC   -   ivINT_CAN1_Error               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x38  0x000000E0   -   ivINT_CAN1_Tx_Warning          unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x39  0x000000E4   -   ivINT_CAN1_Rx_Warning          unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x3A  0x000000E8   -   ivINT_CAN1_Wake_Up             unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x3B  0x000000EC   -   ivINT_Reserved59               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x3C  0x000000F0   -   ivINT_UART0_LON                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x3D  0x000000F4   -   ivINT_UART0_RX_TX              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x3E  0x000000F8   -   ivINT_UART0_ERR                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x3F  0x000000FC   -   ivINT_UART1_RX_TX              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x40  0x00000100   -   ivINT_UART1_ERR                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x41  0x00000104   -   ivINT_UART2_RX_TX              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x42  0x00000108   -   ivINT_UART2_ERR                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x43  0x0000010C   -   ivINT_UART3_RX_TX              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x44  0x00000110   -   ivINT_UART3_ERR                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x45  0x00000114   -   ivINT_UART4_RX_TX              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x46  0x00000118   -   ivINT_UART4_ERR                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x47  0x0000011C   -   ivINT_UART5_RX_TX              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x48  0x00000120   -   ivINT_UART5_ERR                unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x49  0x00000124   -   ivINT_ADC0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x4A  0x00000128   -   ivINT_ADC1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x4B  0x0000012C   -   ivINT_CMP0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x4C  0x00000130   -   ivINT_CMP1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x4D  0x00000134   -   ivINT_CMP2                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x4E  0x00000138   -   ivINT_FTM0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x4F  0x0000013C   -   ivINT_FTM1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x50  0x00000140   -   ivINT_FTM2                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x51  0x00000144   -   ivINT_CMT                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x52  0x00000148   -   ivINT_RTC                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x53  0x0000014C   -   ivINT_RTC_Seconds              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x54  0x00000150   -   ivINT_PIT0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x55  0x00000154   -   ivINT_PIT1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x56  0x00000158   -   ivINT_PIT2                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x57  0x0000015C   -   ivINT_PIT3                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x58  0x00000160   -   ivINT_PDB0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x59  0x00000164   -   ivINT_USB0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x5A  0x00000168   -   ivINT_USBDCD                   unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x5B  0x0000016C   -   ivINT_ENET_1588_Timer          unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x5C  0x00000170   -   ivINT_ENET_Transmit            unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x5D  0x00000174   -   ivINT_ENET_Receive             unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x5E  0x00000178   -   ivINT_ENET_Error               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x5F  0x0000017C   -   ivINT_Reserved95               unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x60  0x00000180   -   ivINT_SDHC                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x61  0x00000184   -   ivINT_DAC0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x62  0x00000188   -   ivINT_DAC1                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x63  0x0000018C   -   ivINT_TSI0                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x64  0x00000190   -   ivINT_MCG                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x65  0x00000194   -   ivINT_LPTimer                  unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x66  0x00000198   -   ivINT_Reserved102              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x67  0x0000019C   -   ivINT_PORTA                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x68  0x000001A0   -   ivINT_PORTB                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x69  0x000001A4   -   ivINT_PORTC                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x6A  0x000001A8   -   ivINT_PORTD                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x6B  0x000001AC   -   ivINT_PORTE                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x6C  0x000001B0   -   ivINT_PORTF                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x6D  0x000001B4   -   ivINT_Reserved109              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x6E  0x000001B8   -   ivINT_SWI                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x6F  0x000001BC   -   ivINT_NFC                      unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x70  0x000001C0   -   ivINT_USBHS                    unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x71  0x000001C4   -   ivINT_Reserved113              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x72  0x000001C8   -   ivINT_CMP3                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x73  0x000001CC   -   ivINT_Reserved115              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x74  0x000001D0   -   ivINT_Reserved116              unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x75  0x000001D4   -   ivINT_FTM3                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x76  0x000001D8   -   ivINT_ADC2                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x77  0x000001DC   -   ivINT_ADC3                     unused by PE */
-    (tIsrFunc)&Cpu_Interrupt,          /* 0x78  0x000001E0   -   ivINT_I2S1_Tx                  unused by PE */
-    (tIsrFunc)&Cpu_Interrupt           /* 0x79  0x000001E4   -   ivINT_I2S1_Rx                  unused by PE */
-    }
-  };
-
-#else
 
 /** \brief LPC4337 Interrupt vector */
 __attribute__ ((section(".isr_vector")))

--- a/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
@@ -235,26 +235,26 @@ switch ($definition["CPU"])
          83 => "TSI0",
          84 => "MCG",
          84 => "LPTimer",
-         86 => "RES102",
-         87 => "PORTA",
-         88 => "PORTB",
-         89 => "PORTC",
-         90 => "PORTD",
-         91 => "PORTE",
-         92 => "PORTF",
-         93 => "RES109",
-         94 => "SWI",
-         95 => "NFC",
-         96 => "USBHS",
-         97 => "RES113",
-         98 => "CMP3",
-         99 => "RES115",
-         100 => "RES116",
-         101 => "FTM3",
-         102 => "ADC2",
-         103 => "ADC3",
-         104 => "I2S1_TX",
-         105 => "I2S1_RX",
+         85 => "RES102",
+         86 => "PORTA",
+         87 => "PORTB",
+         88 => "PORTC",
+         89 => "PORTD",
+         90 => "PORTE",
+         91 => "PORTF",
+         92 => "RES109",
+         93 => "SWI",
+         94 => "NFC",
+         95 => "USBHS",
+         96 => "RES113",
+         97 => "CMP3",
+         98 => "RES115",
+         99 => "RES116",
+         100 => "FTM3",
+         101 => "ADC2",
+         102 => "ADC3",
+         103 => "I2S1_TX",
+         104 => "I2S1_RX",
       );
       break;
 
@@ -444,11 +444,10 @@ for($i=0; $i < $MAX_INT_COUNT; $i++)
       print "   OSEK_ISR_NoHandler, /* No Handler set for ISR " . $intList[$i] . " (IRQ $i) */\n";
    }
 }
+else :
+   error("Not supported CPU: " . $definition["CPU"]);
+endif;
 ?>
-};
-#else
-#error Not supported CPU
-#endif
 
 /** \brief Interrupt enabling and priority setting function */
 void Enable_User_ISRs(void)

--- a/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
@@ -2,9 +2,10 @@
  * DO NOT CHANGE THIS FILE, IT IS GENERATED AUTOMATICALY*
  ********************************************************/
 
-/* Copyright 2014, Mariano Cerdeiro
+/* Copyright 2014, 2015 Mariano Cerdeiro
  * Copyright 2014, Pablo Ridolfi
  * Copyright 2015, Alejandro Permingeat
+ * All rights reserved.
  *
  * This file is part of CIAA Firmware.
  *
@@ -68,6 +69,10 @@
 /*==================[inclusions]=============================================*/
 #include "Os_Internal.h"
 
+#if (CPU == mk60fx512vlq15)
+#include "Cpu.h"
+#endif
+
 /*==================[macros and definitions]=================================*/
 
 /*==================[internal data declaration]==============================*/
@@ -77,22 +82,19 @@
 /*==================[internal data definition]===============================*/
 
 /*==================[external data definition]===============================*/
-
 #if (CPU == mk60fx512vlq15)
-  #include "Cpu.h"
-/* __thumb_startup is defined in startup.c */
-  void __thumb_startup( void );
+   /* __thumb_startup is defined in startup.c */
+   void __thumb_startup( void );
 
-  extern uint32_t __SP_INIT;
-
-#else
-
+   extern uint32_t __SP_INIT;
+#elif (CPU == lpc4337)
 /* ResetISR is defined in cr_startup_lpc43xx.c */
 extern void ResetISR(void);
 
 /** \brief External declaration for the pointer to the stack top from the Linker Script */
 extern void _vStackTop(void);
-
+#else
+#error Not supported CPU
 #endif
 
 /** \brief Handlers used by OSEK */
@@ -100,7 +102,6 @@ extern void SysTick_Handler(void);
 extern void PendSV_Handler(void);
 
 /*==================[internal functions definition]==========================*/
-
 /* Default exception handlers. */
 __attribute__ ((section(".after_vectors")))
 void NMI_Handler(void) {
@@ -273,13 +274,10 @@ $intList_k60_120 = array (
 $MAX_INT_COUNT_k60_120 = max(array_keys($intList_k60_120))+1;
 ?>
 
-
-
-
 #if (CPU == mk60fx512vlq15)
 /** \brief mk60fx512vlq15 Interrupt vector */
 __attribute__ ((section (".vectortable"))) const tVectorTable __vect_table = { /* Interrupt vector table */
-  
+
     /* ISR name                             No. Address      Pri Name                           Description */
     &__SP_INIT,                        /* 0x00  0x00000000   -   ivINT_Initial_Stack_Pointer    used by PE */
     {
@@ -336,7 +334,7 @@ for($i=16; $i < $MAX_INT_COUNT_k60_120; $i++)
 	}
   };
 
-#else
+#elif (CPU == lpc4337)
 
 <?php
 /* Interrupt sources for LPC43xx.
@@ -459,6 +457,8 @@ for($i=0; $i < $MAX_INT_COUNT; $i++)
 }
 ?>
 };
+#else
+#error Not supported CPU
 #endif
 
 /** \brief Interrupt enabling and priority setting function */

--- a/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
@@ -4,6 +4,7 @@
 
 /* Copyright 2014, Mariano Cerdeiro
  * Copyright 2014, Pablo Ridolfi
+ * Copyright 2015, Alejandro Permingeat
  *
  * This file is part of CIAA Firmware.
  *
@@ -58,6 +59,7 @@
 /*
  * modification history (new versions first)
  * -----------------------------------------------------------
+ * v0.1.3 20150303 Apermingeat added K60_120 interrupt sources
  * v0.1.2 20141130 PR   Added ISR cat. 2 enabling and disabling functions.
  * v0.1.1 20141115 PR   added LPC43xx interrupt sources, spelling mistake fixed
  * v0.1.0 20141115 MaCe initial version
@@ -76,11 +78,23 @@
 
 /*==================[external data definition]===============================*/
 
+#if (CPU == mk60fx512vlq15)
+  #include "Cpu.h"
+/* __thumb_startup is defined in startup.c */
+  void __thumb_startup( void );
+
+  extern uint32_t __SP_INIT;
+  //extern uint32_t __SP_INIT;
+
+#else
+
 /* ResetISR is defined in cr_startup_lpc43xx.c */
 extern void ResetISR(void);
 
 /** \brief External declaration for the pointer to the stack top from the Linker Script */
 extern void _vStackTop(void);
+
+#endif
 
 /** \brief Handlers used by OSEK */
 extern void SysTick_Handler(void);
@@ -189,6 +203,140 @@ $intList = array (
 
 $MAX_INT_COUNT = max(array_keys($intList))+1;
 ?>
+
+#if (CPU == mk60fx512vlq15)
+/** \brief mk60fx512vlq15 Interrupt vector */
+__attribute__ ((section (".vectortable"))) const tVectorTable __vect_table = { /* Interrupt vector table */
+  
+    /* ISR name                             No. Address      Pri Name                           Description */
+    &__SP_INIT,                        /* 0x00  0x00000000   -   ivINT_Initial_Stack_Pointer    used by PE */
+    {
+    (tIsrFunc)&__thumb_startup,        /* 0x01  0x00000004   -   ivINT_Initial_Program_Counter  used by PE */
+    (tIsrFunc)&Cpu_INT_NMIInterrupt,   /* 0x02  0x00000008   -2   ivINT_NMI                      used by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x03  0x0000000C   -1   ivINT_Hard_Fault               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x04  0x00000010   -   ivINT_Mem_Manage_Fault         unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x05  0x00000014   -   ivINT_Bus_Fault                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x06  0x00000018   -   ivINT_Usage_Fault              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x07  0x0000001C   -   ivINT_Reserved7                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x08  0x00000020   -   ivINT_Reserved8                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x09  0x00000024   -   ivINT_Reserved9                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0A  0x00000028   -   ivINT_Reserved10               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0B  0x0000002C   -   ivINT_SVCall                   unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0C  0x00000030   -   ivINT_DebugMonitor             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0D  0x00000034   -   ivINT_Reserved13               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x0E  0x00000038   -   ivINT_PendableSrvReq           unused by PE */
+    (tIsrFunc)&SysTick_Handler,        /* 0x0F  0x0000003C   -   ivINT_SysTick                  unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x10  0x00000040   -   ivINT_DMA0_DMA16               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x11  0x00000044   -   ivINT_DMA1_DMA17               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x12  0x00000048   -   ivINT_DMA2_DMA18               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x13  0x0000004C   -   ivINT_DMA3_DMA19               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x14  0x00000050   -   ivINT_DMA4_DMA20               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x15  0x00000054   -   ivINT_DMA5_DMA21               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x16  0x00000058   -   ivINT_DMA6_DMA22               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x17  0x0000005C   -   ivINT_DMA7_DMA23               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x18  0x00000060   -   ivINT_DMA8_DMA24               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x19  0x00000064   -   ivINT_DMA9_DMA25               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x1A  0x00000068   -   ivINT_DMA10_DMA26              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x1B  0x0000006C   -   ivINT_DMA11_DMA27              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x1C  0x00000070   -   ivINT_DMA12_DMA28              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x1D  0x00000074   -   ivINT_DMA13_DMA29              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x1E  0x00000078   -   ivINT_DMA14_DMA30              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x1F  0x0000007C   -   ivINT_DMA15_DMA31              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x20  0x00000080   -   ivINT_DMA_Error                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x21  0x00000084   -   ivINT_MCM                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x22  0x00000088   -   ivINT_FTFE                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x23  0x0000008C   -   ivINT_Read_Collision           unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x24  0x00000090   -   ivINT_LVD_LVW                  unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x25  0x00000094   -   ivINT_LLW                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x26  0x00000098   -   ivINT_Watchdog                 unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x27  0x0000009C   -   ivINT_RNG                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x28  0x000000A0   -   ivINT_I2C0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x29  0x000000A4   -   ivINT_I2C1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x2A  0x000000A8   -   ivINT_SPI0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x2B  0x000000AC   -   ivINT_SPI1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x2C  0x000000B0   -   ivINT_SPI2                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x2D  0x000000B4   -   ivINT_CAN0_ORed_Message_buffer unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x2E  0x000000B8   -   ivINT_CAN0_Bus_Off             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x2F  0x000000BC   -   ivINT_CAN0_Error               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x30  0x000000C0   -   ivINT_CAN0_Tx_Warning          unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x31  0x000000C4   -   ivINT_CAN0_Rx_Warning          unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x32  0x000000C8   -   ivINT_CAN0_Wake_Up             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x33  0x000000CC   -   ivINT_I2S0_Tx                  unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x34  0x000000D0   -   ivINT_I2S0_Rx                  unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x35  0x000000D4   -   ivINT_CAN1_ORed_Message_buffer unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x36  0x000000D8   -   ivINT_CAN1_Bus_Off             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x37  0x000000DC   -   ivINT_CAN1_Error               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x38  0x000000E0   -   ivINT_CAN1_Tx_Warning          unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x39  0x000000E4   -   ivINT_CAN1_Rx_Warning          unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x3A  0x000000E8   -   ivINT_CAN1_Wake_Up             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x3B  0x000000EC   -   ivINT_Reserved59               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x3C  0x000000F0   -   ivINT_UART0_LON                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x3D  0x000000F4   -   ivINT_UART0_RX_TX              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x3E  0x000000F8   -   ivINT_UART0_ERR                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x3F  0x000000FC   -   ivINT_UART1_RX_TX              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x40  0x00000100   -   ivINT_UART1_ERR                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x41  0x00000104   -   ivINT_UART2_RX_TX              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x42  0x00000108   -   ivINT_UART2_ERR                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x43  0x0000010C   -   ivINT_UART3_RX_TX              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x44  0x00000110   -   ivINT_UART3_ERR                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x45  0x00000114   -   ivINT_UART4_RX_TX              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x46  0x00000118   -   ivINT_UART4_ERR                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x47  0x0000011C   -   ivINT_UART5_RX_TX              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x48  0x00000120   -   ivINT_UART5_ERR                unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x49  0x00000124   -   ivINT_ADC0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x4A  0x00000128   -   ivINT_ADC1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x4B  0x0000012C   -   ivINT_CMP0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x4C  0x00000130   -   ivINT_CMP1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x4D  0x00000134   -   ivINT_CMP2                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x4E  0x00000138   -   ivINT_FTM0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x4F  0x0000013C   -   ivINT_FTM1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x50  0x00000140   -   ivINT_FTM2                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x51  0x00000144   -   ivINT_CMT                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x52  0x00000148   -   ivINT_RTC                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x53  0x0000014C   -   ivINT_RTC_Seconds              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x54  0x00000150   -   ivINT_PIT0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x55  0x00000154   -   ivINT_PIT1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x56  0x00000158   -   ivINT_PIT2                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x57  0x0000015C   -   ivINT_PIT3                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x58  0x00000160   -   ivINT_PDB0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x59  0x00000164   -   ivINT_USB0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x5A  0x00000168   -   ivINT_USBDCD                   unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x5B  0x0000016C   -   ivINT_ENET_1588_Timer          unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x5C  0x00000170   -   ivINT_ENET_Transmit            unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x5D  0x00000174   -   ivINT_ENET_Receive             unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x5E  0x00000178   -   ivINT_ENET_Error               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x5F  0x0000017C   -   ivINT_Reserved95               unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x60  0x00000180   -   ivINT_SDHC                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x61  0x00000184   -   ivINT_DAC0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x62  0x00000188   -   ivINT_DAC1                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x63  0x0000018C   -   ivINT_TSI0                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x64  0x00000190   -   ivINT_MCG                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x65  0x00000194   -   ivINT_LPTimer                  unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x66  0x00000198   -   ivINT_Reserved102              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x67  0x0000019C   -   ivINT_PORTA                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x68  0x000001A0   -   ivINT_PORTB                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x69  0x000001A4   -   ivINT_PORTC                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x6A  0x000001A8   -   ivINT_PORTD                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x6B  0x000001AC   -   ivINT_PORTE                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x6C  0x000001B0   -   ivINT_PORTF                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x6D  0x000001B4   -   ivINT_Reserved109              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x6E  0x000001B8   -   ivINT_SWI                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x6F  0x000001BC   -   ivINT_NFC                      unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x70  0x000001C0   -   ivINT_USBHS                    unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x71  0x000001C4   -   ivINT_Reserved113              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x72  0x000001C8   -   ivINT_CMP3                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x73  0x000001CC   -   ivINT_Reserved115              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x74  0x000001D0   -   ivINT_Reserved116              unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x75  0x000001D4   -   ivINT_FTM3                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x76  0x000001D8   -   ivINT_ADC2                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x77  0x000001DC   -   ivINT_ADC3                     unused by PE */
+    (tIsrFunc)&Cpu_Interrupt,          /* 0x78  0x000001E0   -   ivINT_I2S1_Tx                  unused by PE */
+    (tIsrFunc)&Cpu_Interrupt           /* 0x79  0x000001E4   -   ivINT_I2S1_Rx                  unused by PE */
+    }
+  };
+
+#else
+
 /** \brief LPC4337 Interrupt vector */
 __attribute__ ((section(".isr_vector")))
 void (* const g_pfnVectors[])(void) = {
@@ -247,6 +395,7 @@ for($i=0; $i < $MAX_INT_COUNT; $i++)
 }
 ?>
 };
+#endif
 
 /** \brief Interrupt enabling and priority setting function */
 void Enable_User_ISRs(void)

--- a/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
@@ -81,10 +81,10 @@
 
 /*==================[external data definition]===============================*/
 #if (CPU == mk60fx512vlq15)
-   /* __thumb_startup is defined in startup.c */
-   void __thumb_startup( void );
+   /* Reset_Handler is defined in startup_MK60F15.S_CPP */
+   void Reset_Handler( void );
 
-   extern uint32_t __SP_INIT;
+   extern uint32_t __StackTop;
 #elif (CPU == lpc4337)
 /* ResetISR is defined in cr_startup_lpc43xx.c */
 extern void ResetISR(void);
@@ -324,25 +324,25 @@ switch ($definition["CPU"])
 $MAX_INT_COUNT = max(array_keys($intList))+1;
 
 if ($definition["CPU"] == "mk60fx512vlq15") : ?>
-/** \brief mk60fx512vlq15 Interrupt vector */
-__attribute__ ((section (".vectortable"))) void const * const  __vect_table[] = { /* Interrupt vector table */
+__attribute__ ((section(".isr_vector")))
+void (* const g_pfnVectors[])(void) = {
    /* System ISRs */
-   &__SP_INIT,
-   (void*)&__thumb_startup,
-   (void*)&NMI_Handler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&OSEK_ISR_NoHandler,
-   (void*)&SysTick_Handler,
+   &__StackTop,                    /* The initial stack pointer  */
+   Reset_Handler,                       /* The reset handler          */
+   NMI_Handler,                    /* The NMI handler            */
+   HardFault_Handler,              /* The hard fault handler     */
+   MemManage_Handler,              /* The MPU fault handler      */
+   BusFault_Handler,               /* The bus fault handler      */
+   UsageFault_Handler,             /* The usage fault handler    */
+   0,                              /* Reserved                   */
+   0,                              /* Reserved                   */
+   0,                              /* Reserved                   */
+   0,                              /* Reserved                   */
+   SVC_Handler,                    /* SVCall handler             */
+   DebugMon_Handler,               /* Debug monitor handler      */
+   0,                              /* Reserved                   */
+   PendSV_Handler,                 /* The PendSV handler         */
+   SysTick_Handler,                /* The SysTick handler        */
 <?php elseif ($definition["CPU"] == "lpc4337") : ?>
 /** \brief LPC4337 Interrupt vector */
 __attribute__ ((section(".isr_vector")))

--- a/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM4/Os_Internal_Arch_Cfg.c.php
@@ -55,11 +55,13 @@
  * ---------------------------
  * MaCe         Mariano Cerdeiro
  * PR           Pablo Ridolfi
+ * Apermingeat  Alejandro Permingeat
  */
 
 /*
  * modification history (new versions first)
  * -----------------------------------------------------------
+ * v0.1.4 20150307 MaCe rework port for CIAA-FLS
  * v0.1.3 20150303 Apermingeat added K60_120 interrupt sources
  * v0.1.2 20141130 PR   Added ISR cat. 2 enabling and disabling functions.
  * v0.1.1 20141115 PR   added LPC43xx interrupt sources, spelling mistake fixed
@@ -68,7 +70,6 @@
 
 /*==================[inclusions]=============================================*/
 #include "Os_Internal.h"
-
 #if (CPU == mk60fx512vlq15)
 #include "Cpu.h"
 #endif
@@ -140,141 +141,194 @@ void DebugMon_Handler(void) {
 }
 
 /*==================[external functions definition]==========================*/
-
 <?php
-/* Interrupt sources for MK60F15.
- * See externals/platforms/cortexM4/k60_120/inc/MK60F15.h.
- */
-$intList_k60_120 = array (
-   0 => "Initial_Stack_Pointer",
-   1 => "Initial_Program_Counter",
-   2 => "NMI",
-   3 => "Hard_Fault",
-   4 => "Mem_Manage_Fault",
-   5 => "Bus_Fault",
-   6 => "Usage_Fault",
-   7 => "Reserved7",
-   8 => "Reserved8",
-   9 => "Reserved9",
-   10 => "Reserved10",
-   11 => "SVCall",
-   12 => "DebugMonitor",
-   13 => "Reserved13",
-   14 => "PendableSrvReq",
-   15 => "SysTick",
-   16 => "DMA0_DMA16",
-   17 => "DMA1_DMA17",
-   18 => "DMA2_DMA18",
-   19 => "DMA3_DMA19",
-   20 => "DMA4_DMA20",
-   21 => "DMA5_DMA21",
-   22 => "DMA6_DMA22",
-   23 => "DMA7_DMA23",
-   24 => "DMA8_DMA24",
-   25 => "DMA9_DMA25",
-   26 => "DMA10_DMA26",
-   27 => "DMA11_DMA27",
-   28 => "DMA12_DMA28",
-   29 => "DMA13_DMA29",
-   30 => "DMA14_DMA30",
-   31 => "DMA15_DMA31",
-   32 => "DMA_Error",
-   33 => "MCM",
-   34 => "FTFE",
-   35 => "Read_Collision",
-   36 => "LVD_LVW",
-   37 => "LLW",
-   38 => "Watchdog",
-   39 => "RNG",
-   40 => "I2C0",
-   41 => "I2C1",
-   42 => "SPI0",
-   43 => "SPI1",
-   44 => "SPI2",
-   45 => "CAN0_ORed_Message_buffer",
-   46 => "CAN0_Bus_Off",
-   47 => "CAN0_Error",
-   48 => "CAN0_Tx_Warning",
-   49 => "CAN0_Rx_Warning",
-   50 => "CAN0_Wake_Up",
-   51 => "I2S0_Tx",
-   52 => "I2S0_Rx",
-   53 => "CAN1_ORed_Message_buffer",
-   54 => "CAN1_Bus_Off",
-   55 => "CAN1_Error",
-   56 => "CAN1_Tx_Warning",
-   57 => "CAN1_Rx_Warning",
-   58 => "CAN1_Wake_Up",
-   59 => "Reserved59",
-   60 => "UART0_LON",
-   61 => "UART0_RX_TX",
-   62 => "UART0_ERR",
-   63 => "UART1_RX_TX",
-   64 => "UART1_ERR",
-   65 => "UART2_RX_TX",
-   66 => "UART2_ERR",
-   67 => "UART3_RX_TX",
-   68 => "UART3_ERR",
-   69 => "UART4_RX_TX",
-   70 => "UART4_ERR",
-   71 => "UART5_RX_TX",
-   72 => "UART5_ERR",
-   73 => "ADC0",
-   74 => "ADC1",
-   75 => "CMP0",
-   76 => "CMP1",
-   77 => "CMP2",
-   78 => "FTM0",
-   79 => "FTM1",
-   80 => "FTM2",
-   81 => "CMT",
-   82 => "RTC",
-   83 => "RTC_Seconds",
-   84 => "PIT0",
-   85 => "PIT1",
-   86 => "PIT2",
-   87 => "PIT3",
-   88 => "PDB0",
-   89 => "USB0",
-   90 => "USBDCD",
-   91 => "ENET_1588_Timer",
-   92 => "ENET_Transmit",
-   93 => "ENET_Receive",
-   94 => "ENET_Error",
-   95 => "Reserved95",
-   96 => "SDHC",
-   97 => "DAC0",
-   98 => "DAC1",
-   99 => "TSI0",
-   100 => "MCG",
-   101 => "LPTimer",
-   102 => "Reserved102",
-   103 => "PORTA",
-   104 => "PORTB",
-   105 => "PORTC",
-   106 => "PORTD",
-   107 => "PORTE",
-   108 => "PORTF",
-   109 => "Reserved109",
-   110 => "SWI",
-   111 => "NFC",
-   112 => "USBHS",
-   113 => "Reserved113",
-   114 => "CMP3",
-   115 => "Reserved115",
-   116 => "Reserved116",
-   117 => "FTM3",
-   118 => "ADC2",
-   119 => "ADC3",
-   120 => "I2S1_Tx",
-   121 => "I2S1_Rx",
+switch ($definition["CPU"])
+{
+   case "mk60fx512vlq15":
+      /* Interrupt sources for MK60F15.
+       * See externals/platforms/cortexM4/k60_120/inc/MK60F15.h.
+       */
+      $intList = array (
+         0 => "DMA0_DMA16",
+         1 => "DMA1_DMA17",
+         2 => "DMA2_DMA18",
+         3 => "DMA3_DMA19",
+         4 => "DMA4_DMA20",
+         5 => "DMA5_DMA21",
+         6 => "DMA6_DMA22",
+         7 => "DMA7_DMA23",
+         8 => "DMA8_DMA24",
+         9 => "DMA9_DMA25",
+         10 => "DMA10_DMA26",
+         11 => "DMA11_DMA27",
+         12 => "DMA12_DMA28",
+         13 => "DMA13_DMA29",
+         14 => "DMA14_DMA30",
+         15 => "DMA15_DMA31",
+         16 => "DMA_ERR",
+         17 => "MCM",
+         18 => "FTFE",
+         19 => "Read_Collision",
+         20 => "LVD_LVW",
+         21 => "LLW",
+         22 => "WDG",
+         23 => "RNG",
+         24 => "I2C0",
+         25 => "I2C1",
+         26 => "SPI0",
+         27 => "SPI1",
+         28 => "SPI2",
+         29 => "CAN0_READ",
+         30 => "CAN0_BOFF",
+         31 => "CAN0_ERR",
+         32 => "CAN0_TXW",
+         33 => "CAN0_RXW",
+         34 => "CAN0_WAKEUP",
+         35 => "I2S0_TX",
+         36 => "I2S0_RR",
+         37 => "CAN1_READ",
+         38 => "CAN1_BOFF",
+         39 => "CAN1_EERROR",
+         40 => "CAN1_TXW",
+         41 => "CAN1_RXW",
+         42 => "CAN1_WAKEUP",
+         43 => "RES59",
+         44 => "UART0_LON",
+         45 => "UART0",
+         46 => "UART0_ERR",
+         47 => "UART1",
+         48 => "UART1_ERR",
+         49 => "UART2",
+         50 => "UART2_ERR",
+         51 => "UART3",
+         52 => "UART3_ERR",
+         53 => "UART4",
+         54 => "UART4_ERR",
+         55 => "UART5",
+         56 => "UART5_ERR",
+         57 => "ADC0",
+         58 => "ADC1",
+         59 => "CMP0",
+         60 => "CMP1",
+         61 => "CMP2",
+         62 => "FTM0",
+         63 => "FTM1",
+         64 => "FTM2",
+         65 => "CMT",
+         66 => "RTC",
+         67 => "RTC_SEC",
+         68 => "PIT0",
+         69 => "PIT1",
+         70 => "PIT2",
+         71 => "PIT3",
+         72 => "PDB0",
+         73 => "USB0",
+         74 => "USBDCD",
+         75 => "ENET_1588_Timer",
+         76 => "ENET_TX",
+         77 => "ENET_RX",
+         78 => "ENET_ERR",
+         79 => "RES95",
+         80 => "SDHC",
+         81 => "DAC0",
+         82 => "DAC1",
+         83 => "TSI0",
+         84 => "MCG",
+         84 => "LPTimer",
+         86 => "RES102",
+         87 => "PORTA",
+         88 => "PORTB",
+         89 => "PORTC",
+         90 => "PORTD",
+         91 => "PORTE",
+         92 => "PORTF",
+         93 => "RES109",
+         94 => "SWI",
+         95 => "NFC",
+         96 => "USBHS",
+         97 => "RES113",
+         98 => "CMP3",
+         99 => "RES115",
+         100 => "RES116",
+         101 => "FTM3",
+         102 => "ADC2",
+         103 => "ADC3",
+         104 => "I2S1_TX",
+         105 => "I2S1_RX",
+      );
+      break;
 
-);
+   case "lpc4337":
+      /* Interrupt sources for LPC43xx.
+       * See externals/platforms/cortexM4/lpc43xx/inc/cmsis_43xx.h.
+       */
+      $intList = array (
+         0 => "DAC",
+         1 => "M0APP",
+         2 => "DMA",
+         3 => "RES1",
+         4 => "FLASH_EEPROM",
+         5 => "ETH",
+         6 => "SDIO",
+         7 => "LCD",
+         8 => "USB0",
+         9 => "USB1",
+         10 => "SCT",
+         11 => "RIT",
+         12 => "TIMER0",
+         13 => "TIMER1",
+         14 => "TIMER2",
+         15 => "TIMER3",
+         16 => "MCPWM",
+         17 => "ADC0",
+         18 => "I2C0",
+         19 => "I2C1",
+         20 => "SPI",
+         21 => "ADC1",
+         22 => "SSP0",
+         23 => "SSP1",
+         24 => "UART0",
+         25 => "UART1",
+         26 => "UART2",
+         27 => "UART3",
+         28 => "I2S0",
+         29 => "I2S1",
+         30 => "SPIFI",
+         31 => "SGPIO",
+         32 => "GPIO0",
+         33 => "GPIO1",
+         34 => "GPIO2",
+         35 => "GPIO3",
+         36 => "GPIO4",
+         37 => "GPIO5",
+         38 => "GPIO6",
+         39 => "GPIO7",
+         40 => "GINT0",
+         41 => "GINT1",
+         42 => "EVRT",
+         43 => "CAN1",
+         44 => "RES6",
+         45 => "ADCHS",
+         46 => "ATIMER",
+         47 => "RTC",
+         48 => "RES8",
+         49 => "WDT",
+         50 => "M0SUB",
+         51 => "CAN0",
+         52 => "QEI"
+      );
+      break;
 
-$MAX_INT_COUNT_k60_120 = max(array_keys($intList_k60_120))+1;
+   default:
+      error("the CPU " . $definition["CPU"] . " is not supported.");
+      break;
+}
+
+$MAX_INT_COUNT = max(array_keys($intList))+1;
 ?>
 
 #if (CPU == mk60fx512vlq15)
+<?php if ($definition["CPU"] == "mk60fx512vlq15") : ?>
 /** \brief mk60fx512vlq15 Interrupt vector */
 __attribute__ ((section (".vectortable"))) const tVectorTable __vect_table = { /* Interrupt vector table */
 
@@ -301,7 +355,7 @@ __attribute__ ((section (".vectortable"))) const tVectorTable __vect_table = { /
 /* get ISRs defined by user application */
 $intnames = $config->getList("/OSEK","ISR");
 
-for($i=16; $i < $MAX_INT_COUNT_k60_120; $i++)
+for($i=0; $i < $MAX_INT_COUNT; $i++)
 {
    $src_found = 0;
    foreach ($intnames as $int)
@@ -309,15 +363,15 @@ for($i=16; $i < $MAX_INT_COUNT_k60_120; $i++)
       $intcat = $config->getValue("/OSEK/" . $int,"CATEGORY");
       $source = $config->getValue("/OSEK/" . $int,"INTERRUPT");
 
-      if($intList_k60_120[$i] == $source)
+      if($intList[$i] == $source)
       {
          if ($intcat == 2)
          {
-            print "    (tIsrFunc)&OSEK_ISR2_$int,          /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))." ISR for " . $intList_k60_120[$i] . " (IRQ $i) Category 2 */\n";
+            print "    (tIsrFunc)&OSEK_ISR2_$int,          /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))." ISR for " . $intList[$i] . " (IRQ $i) Category 2 */\n";
             $src_found = 1;
          } elseif ($intcat == 1)
          {
-            print "    (tIsrFunc)&OSEK_ISR_$int,          /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))."  ISR for " . $intList_k60_120[$i] . " (IRQ $i) Category 1 */\n";
+            print "    (tIsrFunc)&OSEK_ISR_$int,          /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))."  ISR for " . $intList[$i] . " (IRQ $i) Category 1 */\n";
             $src_found = 1;
          } else
          {
@@ -327,78 +381,14 @@ for($i=16; $i < $MAX_INT_COUNT_k60_120; $i++)
    }
    if($src_found == 0)
    {
-      print "    (tIsrFunc)&OSEK_ISR_NoHandler,     /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))."   -   No Handler set for ISR " . $intList_k60_120[$i] . " (IRQ $i) */\n";
+      print "    (tIsrFunc)&OSEK_ISR_NoHandler,     /* 0x".dechex($i)."  0x00000".strtoupper(dechex($i*4))."   -   No Handler set for ISR " . $intList[$i] . " (IRQ $i) */\n";
    }
 }
 ?>
-	}
-  };
+   }
+};
 
-#elif (CPU == lpc4337)
-
-<?php
-/* Interrupt sources for LPC43xx.
- * See externals/platforms/cortexM4/lpc43xx/inc/cmsis_43xx.h.
- */
-$intList = array (
-   0 => "DAC",
-   1 => "M0APP",
-   2 => "DMA",
-   3 => "RESERVED1",
-   4 => "FLASH_EEPROM",
-   5 => "ETH",
-   6 => "SDIO",
-   7 => "LCD",
-   8 => "USB0",
-   9 => "USB1",
-   10 => "SCT",
-   11 => "RIT",
-   12 => "TIMER0",
-   13 => "TIMER1",
-   14 => "TIMER2",
-   15 => "TIMER3",
-   16 => "MCPWM",
-   17 => "ADC0",
-   18 => "I2C0",
-   19 => "I2C1",
-   20 => "SPI",
-   21 => "ADC1",
-   22 => "SSP0",
-   23 => "SSP1",
-   24 => "UART0",
-   25 => "UART1",
-   26 => "UART2",
-   27 => "UART3",
-   28 => "I2S0",
-   29 => "I2S1",
-   30 => "SPIFI",
-   31 => "SGPIO",
-   32 => "GPIO0",
-   33 => "GPIO1",
-   34 => "GPIO2",
-   35 => "GPIO3",
-   36 => "GPIO4",
-   37 => "GPIO5",
-   38 => "GPIO6",
-   39 => "GPIO7",
-   40 => "GINT0",
-   41 => "GINT1",
-   42 => "EVRT",
-   43 => "CAN1",
-   44 => "RESERVED6",
-   45 => "ADCHS",
-   46 => "ATIMER",
-   47 => "RTC",
-   48 => "RESERVED8",
-   49 => "WDT",
-   50 => "M0SUB",
-   51 => "CAN0",
-   52 => "QEI"
-);
-
-$MAX_INT_COUNT = max(array_keys($intList))+1;
-?>
-
+<?php elseif ($definition["CPU"] == "lpc4337") : ?>
 /** \brief LPC4337 Interrupt vector */
 __attribute__ ((section(".isr_vector")))
 void (* const g_pfnVectors[])(void) = {
@@ -422,7 +412,6 @@ void (* const g_pfnVectors[])(void) = {
 
    /* Chip Level - LPC43xx (M4 core) */
 <?php
-
 /* get ISRs defined by user application */
 $intnames = $config->getList("/OSEK","ISR");
 

--- a/generator/generator.php
+++ b/generator/generator.php
@@ -1,8 +1,9 @@
 <?php
-/* Copyright 2008, 2009 Mariano Cerdeiro
+/* Copyright 2008, 2009, 2015 Mariano Cerdeiro
  * Copyright 2014, ACSE & CADIEEL
  *      ACSE: http://www.sase.com.ar/asociacion-civil-sistemas-embebidos/ciaa/
  *      CADIEEL: http://www.cadieel.org.ar
+ * All rights reserved.
  *
  * This file is part of CIAA Firmware.
  *
@@ -72,33 +73,33 @@ $runagain = false;
  **/
 function comfiles($f)
 {
-	$ret = false;
+   $ret = false;
 
-	if( file_exists($f[0]) && file_exists($f[1]) )
-	{
-		$f1 = file($f[0]);
-		$f2 = file($f[1]);
-		#info("File: " . $f[0] . ", " . $f[1]);
+   if( file_exists($f[0]) && file_exists($f[1]) )
+   {
+      $f1 = file($f[0]);
+      $f2 = file($f[1]);
+      #info("File: " . $f[0] . ", " . $f[1]);
 
-		if(count($f1)==count($f2))
-		{
-			$loopi = 0;
-			for (; ($loopi < count($f1)) && ($f1[$loopi]==$f2[$loopi]); $loopi++)
-			{
-				/* nothing to do */
-			}
+      if(count($f1)==count($f2))
+      {
+         $loopi = 0;
+         for (; ($loopi < count($f1)) && ($f1[$loopi]==$f2[$loopi]); $loopi++)
+         {
+            /* nothing to do */
+         }
          if( ($loopi == count($f1)) )
-			{
-				$ret = true;
-			}
-		}
-	}
-	else
-	{
-#		info("one file doesnt exist!!!!!!!!!!!!!!!!!!!!");
-	}
+         {
+            $ret = true;
+         }
+      }
+   }
+   else
+   {
+      #info("one file doesnt exist!!!!!!!!!!!!!!!!!!!!");
+   }
 
-	return $ret;
+   return $ret;
 
 }
 
@@ -111,16 +112,16 @@ function comfiles($f)
  **/
 function info($msg)
 {
-	global $verbose;
-	global $generating;
-	if($generating == true)
+   global $verbose;
+   global $generating;
+   if($generating == true)
       ob_end_flush();
-	if ($verbose)
-	{
-		print "INFO: " . $msg . "\n";
-	}
-	if($generating == true)
-	ob_start('ob_file_callback');
+   if ($verbose)
+   {
+      print "INFO: " . $msg . "\n";
+   }
+   if($generating == true)
+      ob_start('ob_file_callback');
 }
 
 /** \brief Warning Generator Function
@@ -132,11 +133,11 @@ function info($msg)
  **/
 function warning($msg)
 {
-	ob_end_flush();
-	print "WARNING: " . $msg . "\n";
-	global $warnings;
-	$warnings++;
-	ob_start('ob_file_callback');
+   ob_end_flush();
+   print "WARNING: " . $msg . "\n";
+   global $warnings;
+   $warnings++;
+   ob_start('ob_file_callback');
 }
 
 /** \brief Error Generator Function
@@ -151,13 +152,13 @@ function warning($msg)
  **/
 function error($msg)
 {
-	global $error;
-	ob_end_flush();
-	print "ERROR: " . $msg . "\n";
-	global $errors;
-	$errors++;
-	$error = true;
-	ob_start('ob_file_callback');
+   global $error;
+   ob_end_flush();
+   print "ERROR: " . $msg . "\n";
+   global $errors;
+   $errors++;
+   $error = true;
+   ob_start('ob_file_callback');
 }
 
 /** \brief Abort Generator Function
@@ -169,9 +170,9 @@ function error($msg)
  **/
 function halt($msg)
 {
-	ob_end_flush();
-	error($msg);
-	exit(1);
+   ob_end_flush();
+   error($msg);
+   exit(1);
 }
 
 /*=================[end of user functions]=====================================*/
@@ -182,18 +183,18 @@ $path = "";
 
 function ob_file_callback($buffer)
 {
-	global $ob_file;
-	fwrite($ob_file,$buffer);
+   global $ob_file;
+   fwrite($ob_file,$buffer);
 }
 
 function printCmdLine()
 {
-	print "INFO: the generator was called as follow:\nINFO: ";
-	foreach ($_SERVER['argv'] as $arg)
-	{
-		print "$arg ";
-	}
-	print "\n";
+   print "INFO: the generator was called as follow:\nINFO: ";
+   foreach ($_SERVER['argv'] as $arg)
+   {
+      print "$arg ";
+   }
+   print "\n";
 }
 
 $args = $_SERVER['argv'];
@@ -201,181 +202,192 @@ $path = array_shift($args);
 
 $path = substr($path,0, strlen($path)-strlen("/generator.php"));
 
-print "ciaaFirmware RTOS Generator - Copyright 2008, 2009, Mariano Cerdeiro\n";
+print "ciaaFirmware RTOS Generator - Copyright 2008, 2009, 2015 Mariano Cerdeiro\n";
 print "                              Copyright 2014, ACSE & CADIEEL\n";
 print "         ACSE : http://www.sase.com.ar/asociacion-civil-sistemas-embebidos/ciaa/\n";
-print "         CADIEEL: http://www.cadieel.org.ar\n\n";
+print "         CADIEEL: http://www.cadieel.org.ar\n";
+print "         All rights reserved.\n\n";
 
 foreach ($args as $arg)
 {
-	switch ($arg)
-	{
-		case "--cmdline":
-			printCmdLine();
-			break;
-		case "-l":
-            print "INFO: ------ LICENSE START ------\n";
-            print "INFO: This file is part of CIAA Firmware.\n";
-            print "INFO: Redistribution and use in source and binary forms, with or without\n";
-            print "INFO: modification, are permitted provided that the following conditions are met:\n";
-            print "INFO: 1. Redistributions of source code must retain the above copyright notice,\n";
-            print "INFO: this list of conditions and the following disclaimer.\n";
-            print "INFO: 2. Redistributions in binary form must reproduce the above copyright notice,\n";
-            print "INFO: this list of conditions and the following disclaimer in the documentation\n";
-            print "INFO: and/or other materials provided with the distribution.\n";
-            print "INFO: 3. Neither the name of the copyright holder nor the names of its\n";
-            print "INFO: contributors may be used to endorse or promote products derived from this\n";
-            print "INFO: software without specific prior written permission.\n";
-            print "INFO: THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\n";
-            print "INFO: AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\n";
-            print "INFO: IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\n";
-            print "INFO: ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE\n";
-            print "INFO: LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR\n";
-            print "INFO: CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF\n";
-            print "INFO: SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS\n";
-            print "INFO: INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\n";
-            print "INFO: CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\n";
-            print "INFO: ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\n";
-            print "INFO: POSSIBILITY OF SUCH DAMAGE.\n";
-			print "INFO: ------- LICENSE END -------\n";
-			break;
-		case "-h":
-		case "--help":
-			print "php generator.php [-l] [-h] [--cmdline] -c <CONFIG_1> [<CONFIG_2>] -o <OUTPUTDIR> -f <GENFILE_1> [<GENFILE_2>]\n";
-			print "      -c   indicate the configuration input files\n";
-			print	"      -o   output directory\n";
-			print "      -f   indicate the files to be generated\n";
-			print "   optional parameters:\n";
-			print "      -h   display this help\n";
-			print "      -l   displays a short license overview\n";
-			print "      --cmdline print the command line\n";
-			exit();
-			break;
-		case "-v":
-			$verbose = true;
-			break;
-		case "-c":
-		case "-o":
-		case "-f":
-			$oldarg = $arg;
-			break;
-		default:
-			switch($oldarg)
-				{
-					case "-c":
-						/* add a config file */
-						$configfiles[] = $arg;
-						break;
-					case "-o":
-						/* add an output dir */
-						$outputdir[]= $arg;
-						break;
-					case "-f":
-						/* add generated file */
-						$genfiles[] = $arg;
-						break;
-					default:
-						halt("invalid argument: " . $arg);
-						break;
-				}
-			break;
-	}
+   switch ($arg)
+   {
+   case "--cmdline":
+      printCmdLine();
+      break;
+   case "-l":
+      print "INFO: ------ LICENSE START ------\n";
+      print "INFO: This file is part of CIAA Firmware.\n";
+      print "INFO: Redistribution and use in source and binary forms, with or without\n";
+      print "INFO: modification, are permitted provided that the following conditions are met:\n";
+      print "INFO: 1. Redistributions of source code must retain the above copyright notice,\n";
+      print "INFO: this list of conditions and the following disclaimer.\n";
+      print "INFO: 2. Redistributions in binary form must reproduce the above copyright notice,\n";
+      print "INFO: this list of conditions and the following disclaimer in the documentation\n";
+      print "INFO: and/or other materials provided with the distribution.\n";
+      print "INFO: 3. Neither the name of the copyright holder nor the names of its\n";
+      print "INFO: contributors may be used to endorse or promote products derived from this\n";
+      print "INFO: software without specific prior written permission.\n";
+      print "INFO: THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\n";
+      print "INFO: AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\n";
+      print "INFO: IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\n";
+      print "INFO: ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE\n";
+      print "INFO: LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR\n";
+      print "INFO: CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF\n";
+      print "INFO: SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS\n";
+      print "INFO: INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\n";
+      print "INFO: CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\n";
+      print "INFO: ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\n";
+      print "INFO: POSSIBILITY OF SUCH DAMAGE.\n";
+      print "INFO: ------- LICENSE END -------\n";
+      break;
+   case "-h":
+   case "--help":
+      print "php generator.php [-l] [-h] [--cmdline] [-Ddef[=definition]] -c <CONFIG_1> [<CONFIG_2>] -o <OUTPUTDIR> -f <GENFILE_1> [<GENFILE_2>]\n";
+      print "      -c   indicate the configuration input files\n";
+      print "      -o   output directory\n";
+      print "      -f   indicate the files to be generated\n";
+      print "   optional parameters:\n";
+      print "      -h   display this help\n";
+      print "      -l   displays a short license overview\n";
+      print "      -D   defines\n";
+      print "      --cmdline print the command line\n";
+      exit();
+      break;
+   case "-v":
+      $verbose = true;
+      break;
+   case "-c":
+   case "-o":
+   case "-f":
+      $oldarg = $arg;
+      break;
+   default:
+      if (empty($oldarg))
+      {
+         if (0 == strpos("-D", $arg))
+         {
+            $tmp = explode("=", substr($arg, 2));
+            $definition[$tmp[0]] = $tmp[1];
+         }
+      } else {
+         switch($oldarg)
+         {
+         case "-c":
+            /* add a config file */
+            $configfiles[] = $arg;
+            break;
+         case "-o":
+            /* add an output dir */
+            $outputdir[]= $arg;
+            break;
+         case "-f":
+            /* add generated file */
+            $genfiles[] = $arg;
+            break;
+         default:
+            halt("invalid argument: " . $arg);
+            break;
+         }
+      }
+      break;
+   }
 }
 
 if (count($configfiles)==0)
 {
-	halt("at least one config file shall be provided");
+   halt("at least one config file shall be provided");
 }
 
 if (count($outputdir)!=1)
 {
-	halt("exactly one output directory shall be provided");
+   halt("exactly one output directory shall be provided");
 }
 
 if (count($genfiles)==0)
 {
-	halt("at least one file to be generated shall be provided");
+   halt("at least one file to be generated shall be provided");
 }
 
 if ($verbose)
 {
-	info("list of configuration files:");
-	$count = 1;
-	foreach ($configfiles as $file)
-	{
-		info("configuration file " . $count++ . ": " . $file);
-	}
+   info("list of configuration files:");
+   $count = 1;
+   foreach ($configfiles as $file)
+   {
+      info("configuration file " . $count++ . ": " . $file);
+   }
 
-	info("list of files to be generated:");
-	$count = 1;
-	foreach ($genfiles as $file)
-	{
-		info("generated file " . $count++ . ": " . $file);
-	}
+   info("list of files to be generated:");
+   $count = 1;
+   foreach ($genfiles as $file)
+   {
+      info("generated file " . $count++ . ": " . $file);
+   }
 
-	info("output directory: " . $outputdir[0]);
+   info("output directory: " . $outputdir[0]);
 }
 
 foreach ($configfiles as $file)
 {
-	info("reading " . $file);
-	$config->parseOilFile($file);
+   info("reading " . $file);
+   $config->parseOilFile($file);
 }
 
 foreach ($genfiles as $file)
 {
-	$exits = false;
-	$outfile = $file;
-	$outfile = substr($outfile, 0, strlen($outfile)-4);
-	//print "info aca: pos: ". strpos($outile, "a",1);
-	#while(strpos($outfile,"gen")!==FALSE)
-	{
-		#print "si: $outfile - ";
-		$outfile = substr($outfile, strpos($outfile, "gen")+3);
-		#print "$outfile\n";
-	}
+   $exits = false;
+   $outfile = $file;
+   $outfile = substr($outfile, 0, strlen($outfile)-4);
+   //print "info aca: pos: ". strpos($outile, "a",1);
+   #while(strpos($outfile,"gen")!==FALSE)
+   {
+      #print "si: $outfile - ";
+      $outfile = substr($outfile, strpos($outfile, "gen")+3);
+      #print "$outfile\n";
+   }
    $outfile = $outputdir[0] . $outfile;
-	info("generating ". $file . " to " . $outfile);
-	global $ob_file;
-	if(!file_exists(dirname($outfile)))
-	{
-		mkdir(dirname($outfile), 0777, TRUE);
-	}
-	if(file_exists($outfile))
-	{
-		$exits = true;
-		if(file_exists($outfile . ".old"))
-		{
-			unlink($outfile . ".old");
-		}
-		rename($outfile, $outfile . ".old");
-	}
-	$ob_file = fopen($outfile, "w");
-	ob_start('ob_file_callback');
-	$generating=true;
-	require_once($file);
-	$generating=false;
-	ob_end_flush();
-	fclose($ob_file);
-	if(comfiles(array($outfile, $outfile . ".old")) == false)
-	{
-		if(substr($file, strlen($file) - strlen(".mak.php") ) == ".mak.php")
+   info("generating ". $file . " to " . $outfile);
+   global $ob_file;
+   if(!file_exists(dirname($outfile)))
+   {
+      mkdir(dirname($outfile), 0777, TRUE);
+   }
+   if(file_exists($outfile))
+   {
+      $exits = true;
+      if(file_exists($outfile . ".old"))
       {
-			$runagain = true;
-		}
-	}
+         unlink($outfile . ".old");
+      }
+      rename($outfile, $outfile . ".old");
+   }
+   $ob_file = fopen($outfile, "w");
+   ob_start('ob_file_callback');
+   $generating=true;
+   require_once($file);
+   $generating=false;
+   ob_end_flush();
+   fclose($ob_file);
+   if(comfiles(array($outfile, $outfile . ".old")) == false)
+   {
+      if(substr($file, strlen($file) - strlen(".mak.php") ) == ".mak.php")
+      {
+         $runagain = true;
+      }
+   }
 
 }
 
 info("Generation Finished with WARNINGS: $warnings and ERRORS: $errors");
 if ($errors > 0)
 {
-	exit(1);
+   exit(1);
 }
 elseif($runagain == true)
 {
-	info("a makefile was generated, generation process will be executed again");
-	system("make generate");
+   info("a makefile was generated, generation process will be executed again");
+   system("make generate");
 }
 
 /** @} doxygen end group definition */

--- a/generator/oilParser.php
+++ b/generator/oilParser.php
@@ -113,7 +113,7 @@ class oilParserClass {
 			/* to do */
 			#if ( strpos($this->lines[$l], "/*") !== false )
 			#{
-		   #	$tmp = array ( substr ($this->lines[$l],0, strpos($this->lines[$l], "/*")-1),
+		   #  $tmp = array ( substr ($this->lines[$l],0, strpos($this->lines[$l], "/*")-1),
 			#						substr ($this->lines[$l],strpos($this->lines[$l], "/*")+2), strlen($this->lines[$l]));
 			#	print "t1:" . $tmp[0] . "t2:" . $tmp[1] . "\n";
 			#	$this->lines[$l] = $tmp[0];
@@ -170,9 +170,12 @@ class oilParserClass {
    		}
 	   	else
 		   {
-   			$tmp = split(" ", $tmp);
+            $tmp = split(" ", $tmp);
             $ret[0] = $tmp[0];
-            $ret[1] = $tmp[1];
+            if (!empty($tmp[1]))
+               $ret[1] = $tmp[1];
+            else
+               $ret[1] = "";
    		}
    	}
 		return $ret;

--- a/inc/cortexM4/k60_120/Os_Internal_Arch_Cpu.h
+++ b/inc/cortexM4/k60_120/Os_Internal_Arch_Cpu.h
@@ -66,7 +66,7 @@
 #ifndef CPU
 #error CPU is not defined
 #elif (CPU == mk60fx512vlq15)
-#include "MK60F12.h"
+#include "MK60F15.h"
 #else
 #error Unknown CPU value
 #endif

--- a/src/cortexM4/StartOs_Arch_SysTick.c
+++ b/src/cortexM4/StartOs_Arch_SysTick.c
@@ -73,7 +73,15 @@
 /*==================[external functions definition]==========================*/
 void StartOs_Arch_SysTick(void)
 {
-   /* Activate MemFault, UsageFault and BusFault exceptions */
+#if (CPU == mk60fx512vlq15)
+	//implements here for K60_120 the next things:
+	/* Activate MemFault, UsageFault and BusFault exceptions */
+	/* Set lowest priority for SysTick and PendSV */
+	/* Activate SysTick */
+	/* Update priority set by SysTick_Config */
+
+#else
+	/* Activate MemFault, UsageFault and BusFault exceptions */
    SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk | SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk;
 
    /* Set lowest priority for SysTick and PendSV */
@@ -85,7 +93,9 @@ void StartOs_Arch_SysTick(void)
 
    /* Update priority set by SysTick_Config */
    NVIC_SetPriority(SysTick_IRQn, (1<<__NVIC_PRIO_BITS) - 1);
+#endif
 }
+
 
 /** @} doxygen end group definition */
 /** @} doxygen end group definition */

--- a/src/cortexM4/StartOs_Arch_SysTick.c
+++ b/src/cortexM4/StartOs_Arch_SysTick.c
@@ -73,14 +73,6 @@
 /*==================[external functions definition]==========================*/
 void StartOs_Arch_SysTick(void)
 {
-#if (CPU == mk60fx512vlq15)
-	//implements here for K60_120 the next things:
-	/* Activate MemFault, UsageFault and BusFault exceptions */
-	/* Set lowest priority for SysTick and PendSV */
-	/* Activate SysTick */
-	/* Update priority set by SysTick_Config */
-
-#else
 	/* Activate MemFault, UsageFault and BusFault exceptions */
    SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk | SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk;
 
@@ -93,7 +85,7 @@ void StartOs_Arch_SysTick(void)
 
    /* Update priority set by SysTick_Config */
    NVIC_SetPriority(SysTick_IRQn, (1<<__NVIC_PRIO_BITS) - 1);
-#endif
+
 }
 
 


### PR DESCRIPTION
Incorporation of k60_120 architecture to OSEK is updated in order to be CMSIS complience. Also PendSV and Systick interrupts for k60_120 has been enabled. It has been compiled with firmware branch k60_120_incorporate_interrupts and works (startup OK and task scheduled OK on blinky example. All OSEK tests need to be executed). #202