### PR TITLE
Fix to issue #466 on the main Firmware repository.

### DIFF
--- a/gen/src/cortexM0/Os_Internal_Arch_Cfg.c.php
+++ b/gen/src/cortexM0/Os_Internal_Arch_Cfg.c.php
@@ -52,7 +52,7 @@
 
 /*==================[inclusions]=============================================*/
 #include "Os_Internal.h"
-#if (CPU == lpc43xx)
+#if (CPUTYPE == lpc43xx)
 /* THIS IS A DIRTY WORKAROUND :( ciaa/Firmware#309*/
 #undef FALSE
 #undef TRUE


### PR DESCRIPTION
Fix to issue ciaa/Firmware#466. This issue was originally mentioned on  ciaa/Firmware#464 .

After applying this fix the rtos submodule on the main Firmware repository should be updated to point to the current firmware.modules.rtos HEAD; that would also close issues ciaa/Firmware#465 and ciaa/Firmware#464